### PR TITLE
check for null as key in engineInit

### DIFF
--- a/library/src/main/java/org/signal/aesgcmprovider/AesGcmCipher.java
+++ b/library/src/main/java/org/signal/aesgcmprovider/AesGcmCipher.java
@@ -102,6 +102,9 @@ public class AesGcmCipher extends CipherSpi {
 
   @Override
   protected void engineInit(int opmode, Key key, AlgorithmParameterSpec params, SecureRandom random) throws InvalidAlgorithmParameterException, InvalidKeyException {
+    if(key == null){
+      throw new InvalidAlgorithmParameterException("Got null instead of Key");
+    }
     if (params == null && opmode == Cipher.DECRYPT_MODE) {
       throw new InvalidAlgorithmParameterException("Required GCMParameterSpec for decryption");
     } else if (params == null) {


### PR DESCRIPTION
adding a missing check for the key in case it a null pointer is given to prevent NullPointerExceptions